### PR TITLE
docs: fix whitespace error in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# shell-runtime
+# shell-runtime
 
 > bash runtime engine
 


### PR DESCRIPTION
It looks like we accidentally added non-breaking space after the '#' in the
first line of the README. This corrects it to a regular space.